### PR TITLE
go-test: add inputs.pre

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -15,6 +15,11 @@ on:
         default: '["1.20.x", "1.19.x"]'
         required: false
         type: string
+      pre:
+        description: 'The commands to run in bash'
+        default: ''
+        required: false
+        type: string
 
 jobs:
   test:
@@ -29,6 +34,8 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
         cache: true
+    - run: ${{ inputs.pre }}
+      shell: bash
     - run: go test -race -covermode=atomic -coverprofile=prof.out ./...
       shell: bash
     - uses: shogo82148/actions-goveralls@v1


### PR DESCRIPTION
In some repositories, it need to install some commands before running `go test`.
Thus I add `inputs.pre` option to go-test workflow to install needed commands.

Though setup-go-matrix workflow likes go-test workflow, it do not need the option because it still be able to run arbitrary commands.