### PR TITLE
set check-latest of setup-go to true

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -28,6 +28,7 @@ jobs:
       with:
         go-version-file: go.mod
         cache: true
+        check-latest: true
     - uses: golangci/golangci-lint-action@v4
       with:
         version: latest

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -34,6 +34,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
         cache: true
+        check-latest: true
     - run: ${{ inputs.pre }}
       shell: bash
     - run: go test -race -covermode=atomic -coverprofile=prof.out ./...

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         go-version: ${{ inputs.go-version }}
         cache: true
+        check-latest: true
     - uses: goreleaser/goreleaser-action@v5
       with:
         args: release --rm-dist

--- a/.github/workflows/setup-go-matrix.yml
+++ b/.github/workflows/setup-go-matrix.yml
@@ -34,5 +34,6 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
         cache: true
+        check-latest: true
     - run: ${{ inputs.run }}
       shell: bash


### PR DESCRIPTION
When check-latest is set to false, setup-go refers existent cache first even though new Go version is released.

I'd like to fix any vulnerability immediately.