### PR TITLE
Support Windows Server 2025

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       os-versions:
         description: 'Stringfied JSON object listing GitHub-hosted runnners'
-        default: '["ubuntu-22.04", "windows-2022", "macos-14", "windows-2025"]'
+        default: '["ubuntu-22.04", "windows-2022", "macos-14", "windows-2025"]' # When windows-2025 become stable, remove windows-2022
         required: false
         type: string
       skip-cache:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       os-versions:
         description: 'Stringfied JSON object listing GitHub-hosted runnners'
-        default: '["ubuntu-22.04", "windows-2022", "macos-14"]'
+        default: '["ubuntu-22.04", "windows-2022", "macos-14", "windows-2025"]'
         required: false
         type: string
       skip-cache:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       os-versions:
         description: 'Stringfied JSON object listing GitHub-hosted runnners'
-        default: '["ubuntu-22.04", "windows-2022", "macos-14"]'
+        default: '["ubuntu-22.04", "windows-2022", "macos-14", "windows-2025"]'
         required: false
         type: string
       go-versions:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       os-versions:
         description: 'Stringfied JSON object listing GitHub-hosted runnners'
-        default: '["ubuntu-22.04", "windows-2022", "macos-14", "windows-2025"]'
+        default: '["ubuntu-22.04", "windows-2022", "macos-14", "windows-2025"]' # When windows-2025 become stable, remove windows-2022
         required: false
         type: string
       go-versions:

--- a/.github/workflows/setup-go-matrix.yml
+++ b/.github/workflows/setup-go-matrix.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       os-versions:
         description: 'Stringfied JSON object listing GitHub-hosted runnners'
-        default: '["ubuntu-22.04", "windows-2022", "macos-14"]'
+        default: '["ubuntu-22.04", "windows-2022", "macos-14", "windows-2025"]'
         required: false
         type: string
       go-versions:

--- a/.github/workflows/setup-go-matrix.yml
+++ b/.github/workflows/setup-go-matrix.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       os-versions:
         description: 'Stringfied JSON object listing GitHub-hosted runnners'
-        default: '["ubuntu-22.04", "windows-2022", "macos-14", "windows-2025"]'
+        default: '["ubuntu-22.04", "windows-2022", "macos-14", "windows-2025"]' # When windows-2025 become stable, remove windows-2022
         required: false
         type: string
       go-versions:


### PR DESCRIPTION
Since we support Windows Server 2025, I've added Windows Server 2025 runner for the CI environment.

Runner Image: https://github.com/actions/runner-images/issues/11228