### PR TITLE
update Go versions.

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,7 +12,7 @@ on:
         type: string
       go-versions:
         description: 'Stringfied JSON object listing target Go versions'
-        default: '["1.23.x", "1.22.x"]'
+        default: '["1.24.x", "1.23.x"]'
         required: false
         type: string
       pre:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       go-version:
-        default: '1.22'
+        default: '1.24'
         required: false
         type: string
 

--- a/.github/workflows/setup-go-matrix.yml
+++ b/.github/workflows/setup-go-matrix.yml
@@ -13,7 +13,7 @@ on:
         type: string
       go-versions:
         description: 'Stringfied JSON object listing target Go versions'
-        default: '["1.23.x", "1.22.x"]'
+        default: '["1.24.x", "1.23.x"]'
         required: false
         type: string
       run:


### PR DESCRIPTION
Go 1.24 was released. therefore replace a version used by our workflows.